### PR TITLE
feat: add valid validation

### DIFF
--- a/src/core.service.ts
+++ b/src/core.service.ts
@@ -111,6 +111,10 @@ export class CoreService implements EventHandler, OnModuleInit {
         case MrzDataSubmitMessage.type:
           session.threadId = message.threadId
           content = JsonTransformer.fromJSON(message, MrzDataSubmitMessage)
+          if (!content.mrzData.parsed.valid) {
+            await this.sendText(session.connectionId, 'MRZ_INVALID', session.lang)
+            await this.sendMenuSelection(session)
+          }
           break
         case EMrtdDataSubmitMessage.type:
           content = JsonTransformer.fromJSON(message, EMrtdDataSubmitMessage)

--- a/src/i18n/en/msg.json
+++ b/src/i18n/en/msg.json
@@ -8,6 +8,7 @@
   "MRZ_SUCCESSFUL": "ID Document successfully read.",
   "EMRTD_SUCCESSFUL":"ID Document successfully read.",
   "VERIFICATION_SUCCESSFUL":"Verification successful.",
+  "MRZ_INVALID":"It looks like the MRZ is invalid. Please rescan your document and try again.",
   "MRTD_FAILED":"Your document couldn't be verified. Reason: <reason>.",
   "ROOT_TITTLE": "Context Menu",
   "TIMEOUT_PROCESS": "ID Verification Timed out. Check menu above to start a new ID Verification.",

--- a/src/i18n/es/msg.json
+++ b/src/i18n/es/msg.json
@@ -8,6 +8,7 @@
   "MRZ_SUCCESSFUL":"Documento de identidad leído con éxito.",
   "EMRTD_SUCCESSFUL":"Documento de identidad leído con éxito.",
   "VERIFICATION_SUCCESSFUL":"Verificación exitosa.",
+  "MRZ_INVALID":"Parece que el MRZ no es válido. Por favor, vuelve a escanear tu documento e inténtalo de nuevo.",
   "MRTD_FAILED":"No fue posible verificar tu documento. Motivo: <reason>.",
   "ROOT_TITTLE": "Menú Contextual",
   "TIMEOUT_PROCESS": "La verificación de identidad ha expirado. Revisa el menú de arriba para iniciar una nueva verificación de identidad.",


### PR DESCRIPTION
According to the library documentation used to validate the checksum, the validation is performed by default. If any inconsistency is detected, the result will return `false`, which means the MRZ should be rejected as valid. This issue occurred when the library was used to create the credential. Currently, all data is collected using NFC, which is linked to the unique MRZ threadId. Therefore, the result is validated, and if the MRZ is deemed invalid, a message will be sent indicating this case.