### PR TITLE
fix: support sha-512 for eMRTD verification

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -5,7 +5,7 @@ version: 0.1.0
 appVersion: "1.0"
 dependencies:
   - name: vs-agent-chart
-    version: v1.4.0-dev.49
+    version: v1.5.0-dev.3
     repository: oci://registry-1.docker.io/io2060
     condition: vs-agent-chart.enabled
   - name: vision-service-chart

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   },
   "dependencies": {
     "@2060.io/credo-ts-didcomm-mrtd": "^0.0.17",
-    "@2060.io/vs-agent-client": "^1.4.0-dev.42",
-    "@2060.io/vs-agent-model": "^1.4.0-dev.42",
-    "@2060.io/vs-agent-nestjs-client": "^1.4.0-dev.42",
+    "@2060.io/vs-agent-client": "^1.5.0-dev.3",
+    "@2060.io/vs-agent-model": "^1.5.0-dev.3",
+    "@2060.io/vs-agent-nestjs-client": "^1.5.0-dev.3",
     "@credo-ts/core": "^0.5.11",
     "@nestjs/axios": "^3.1.1",
     "@nestjs/common": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,14 +12,14 @@ importers:
         specifier: ^0.0.17
         version: 0.0.17(@credo-ts/core@0.5.17(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(typescript@5.9.2)
       '@2060.io/vs-agent-client':
-        specifier: ^1.4.0-dev.42
-        version: 1.4.0(@credo-ts/core@0.5.17(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
+        specifier: ^1.5.0-dev.3
+        version: 1.5.0-dev.3(@credo-ts/core@0.5.17(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
       '@2060.io/vs-agent-model':
-        specifier: ^1.4.0-dev.42
-        version: 1.4.0(@credo-ts/core@0.5.17(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
+        specifier: ^1.5.0-dev.3
+        version: 1.5.0-dev.3(@credo-ts/core@0.5.17(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
       '@2060.io/vs-agent-nestjs-client':
-        specifier: ^1.4.0-dev.42
-        version: 1.4.0(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(pg@8.16.3)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
+        specifier: ^1.5.0-dev.3
+        version: 1.5.0-dev.3(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(pg@8.16.3)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
       '@credo-ts/core':
         specifier: ^0.5.11
         version: 0.5.17(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3)
@@ -160,18 +160,18 @@ packages:
   '@2060.io/credo-ts-didcomm-receipts@0.0.7':
     resolution: {integrity: sha512-PTl636yjq9xglqFe1GPzic/4QI6Zu/2HQ94ToDY9mmEo0g7eRQ4S/0pEEHZdWdBY3WYIsZUd3Y78QGi/ZrzAqg==}
 
-  '@2060.io/vs-agent-client@1.4.0':
-    resolution: {integrity: sha512-i81hv4kFrsiSegxxe7GfMHYQo4rJGHj9IJmqqE6zI7bokC2ajD4XLmNhrIVCXIKwS2UcHkuQn2/FfHmv8fafLA==}
+  '@2060.io/vs-agent-client@1.5.0-dev.3':
+    resolution: {integrity: sha512-TSEXg4ZjnXKFVH8Y4Aejb4sB1Kex86O2uFVVcUegOwUHA2lESzYrREPH+iBUuqMpXC6MHKUezyhE1CKbRsx7fg==}
     peerDependencies:
-      '@credo-ts/core': 0.5.18-alpha-20250903145047
+      '@credo-ts/core': 0.5.18-alpha-20250926091534
 
-  '@2060.io/vs-agent-model@1.4.0':
-    resolution: {integrity: sha512-Gj8rHp1kPeSKAj6HHBalkaVYjsqIECALGmiYZkZ+7X3eJAHjIDFB/3ecSywdzCpLS1PdFLWSxcQ1nrBODX74eg==}
+  '@2060.io/vs-agent-model@1.5.0-dev.3':
+    resolution: {integrity: sha512-OKci/NHT4DJOu28PjOfO400N4ckD/nbKesPmYKl0eYdtd5fx4adJBS60ph22LNn6We/OAdTBFcd3+mLU1X5trg==}
     peerDependencies:
-      '@credo-ts/core': 0.5.18-alpha-20250903145047
+      '@credo-ts/core': 0.5.18-alpha-20250926091534
 
-  '@2060.io/vs-agent-nestjs-client@1.4.0':
-    resolution: {integrity: sha512-MZpxL1awvHh8zcRD7vnxyhIfe2FHWA/ldZbLFMcIhPIp7bfayeIb+9d/knRK1EG1YtX4PPWQFTi7OeMBUpnL+w==}
+  '@2060.io/vs-agent-nestjs-client@1.5.0-dev.3':
+    resolution: {integrity: sha512-zjukSIGkTXmNinCsDLS8sZbAZepTeUHwWpc44vs+y2IBYT6isW3Xb4nyGNe+ngUK0DH/N+uAjqz63G+wShU9aw==}
     peerDependencies:
       '@nestjs/common': ^10.0.0
       '@nestjs/core': ^10.0.0
@@ -729,8 +729,8 @@ packages:
   '@credo-ts/core@0.5.17':
     resolution: {integrity: sha512-oZRj6b34PQDlKOzaw0u0WI7ayjbZAVFW07wJNcRIO2vfs1RRl4Obcr7mg365F1l+W5E1UbLizJf5uCeQr/dW4Q==}
 
-  '@credo-ts/core@0.5.18-alpha-20250903145047':
-    resolution: {integrity: sha512-rHsVAx4nayPVRV/IQeuXmZV71mEi0k8wxDSQQQUkQ8luhcoTe04FYpWp4w7uquz3Z8h3dzB2uv73VRtwhVUTLA==}
+  '@credo-ts/core@0.5.18-alpha-20250926091534':
+    resolution: {integrity: sha512-bUkz5lp2Zx/lFymwWHiAxcIPZxxeLfFedrEwqVkBJ2iSCmL6WpplyLOHQeo51OpYxrB3VJ6ryxepVYIuzsWf3g==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -5485,9 +5485,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@2060.io/credo-ts-didcomm-mrtd@0.0.17(@credo-ts/core@0.5.18-alpha-20250903145047(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(typescript@5.9.2)':
+  '@2060.io/credo-ts-didcomm-mrtd@0.0.17(@credo-ts/core@0.5.18-alpha-20250926091534(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(typescript@5.9.2)':
     dependencies:
-      '@credo-ts/core': 0.5.18-alpha-20250903145047(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3)
+      '@credo-ts/core': 0.5.18-alpha-20250926091534(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3)
       '@li0ard/tsemrtd': 0.2.2(typescript@5.9.2)
       '@peculiar/x509': 1.14.0
       '@types/pkijs': 3.0.1
@@ -5521,9 +5521,9 @@ snapshots:
       - typescript
       - web-streams-polyfill
 
-  '@2060.io/vs-agent-client@1.4.0(@credo-ts/core@0.5.17(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)':
+  '@2060.io/vs-agent-client@1.5.0-dev.3(@credo-ts/core@0.5.17(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)':
     dependencies:
-      '@2060.io/vs-agent-model': 1.4.0(@credo-ts/core@0.5.17(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
+      '@2060.io/vs-agent-model': 1.5.0-dev.3(@credo-ts/core@0.5.17(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
       '@credo-ts/core': 0.5.17(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3)
       class-transformer: 0.5.1
       class-validator: 0.14.1
@@ -5538,10 +5538,10 @@ snapshots:
       - typescript
       - web-streams-polyfill
 
-  '@2060.io/vs-agent-client@1.4.0(@credo-ts/core@0.5.18-alpha-20250903145047(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)':
+  '@2060.io/vs-agent-client@1.5.0-dev.3(@credo-ts/core@0.5.18-alpha-20250926091534(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)':
     dependencies:
-      '@2060.io/vs-agent-model': 1.4.0(@credo-ts/core@0.5.18-alpha-20250903145047(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
-      '@credo-ts/core': 0.5.18-alpha-20250903145047(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3)
+      '@2060.io/vs-agent-model': 1.5.0-dev.3(@credo-ts/core@0.5.18-alpha-20250926091534(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
+      '@credo-ts/core': 0.5.18-alpha-20250926091534(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3)
       class-transformer: 0.5.1
       class-validator: 0.14.1
       express: 4.21.2
@@ -5555,7 +5555,7 @@ snapshots:
       - typescript
       - web-streams-polyfill
 
-  '@2060.io/vs-agent-model@1.4.0(@credo-ts/core@0.5.17(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)':
+  '@2060.io/vs-agent-model@1.5.0-dev.3(@credo-ts/core@0.5.17(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)':
     dependencies:
       '@2060.io/credo-ts-didcomm-mrtd': 0.0.17(@credo-ts/core@0.5.17(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(typescript@5.9.2)
       '@2060.io/credo-ts-didcomm-receipts': 0.0.7(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
@@ -5572,11 +5572,11 @@ snapshots:
       - typescript
       - web-streams-polyfill
 
-  '@2060.io/vs-agent-model@1.4.0(@credo-ts/core@0.5.18-alpha-20250903145047(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)':
+  '@2060.io/vs-agent-model@1.5.0-dev.3(@credo-ts/core@0.5.18-alpha-20250926091534(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)':
     dependencies:
-      '@2060.io/credo-ts-didcomm-mrtd': 0.0.17(@credo-ts/core@0.5.18-alpha-20250903145047(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(typescript@5.9.2)
+      '@2060.io/credo-ts-didcomm-mrtd': 0.0.17(@credo-ts/core@0.5.18-alpha-20250926091534(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(typescript@5.9.2)
       '@2060.io/credo-ts-didcomm-receipts': 0.0.7(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
-      '@credo-ts/core': 0.5.18-alpha-20250903145047(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3)
+      '@credo-ts/core': 0.5.18-alpha-20250926091534(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3)
       class-transformer: 0.5.1
       class-validator: 0.14.1
       mrz: 4.2.1
@@ -5589,12 +5589,12 @@ snapshots:
       - typescript
       - web-streams-polyfill
 
-  '@2060.io/vs-agent-nestjs-client@1.4.0(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(pg@8.16.3)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))(typescript@5.9.2)(web-streams-polyfill@3.3.3)':
+  '@2060.io/vs-agent-nestjs-client@1.5.0-dev.3(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(pg@8.16.3)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))(typescript@5.9.2)(web-streams-polyfill@3.3.3)':
     dependencies:
-      '@2060.io/credo-ts-didcomm-mrtd': 0.0.17(@credo-ts/core@0.5.18-alpha-20250903145047(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(typescript@5.9.2)
-      '@2060.io/vs-agent-client': 1.4.0(@credo-ts/core@0.5.18-alpha-20250903145047(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
-      '@2060.io/vs-agent-model': 1.4.0(@credo-ts/core@0.5.18-alpha-20250903145047(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
-      '@credo-ts/core': 0.5.18-alpha-20250903145047(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3)
+      '@2060.io/credo-ts-didcomm-mrtd': 0.0.17(@credo-ts/core@0.5.18-alpha-20250926091534(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(typescript@5.9.2)
+      '@2060.io/vs-agent-client': 1.5.0-dev.3(@credo-ts/core@0.5.18-alpha-20250926091534(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
+      '@2060.io/vs-agent-model': 1.5.0-dev.3(@credo-ts/core@0.5.18-alpha-20250926091534(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3))(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(typescript@5.9.2)(web-streams-polyfill@3.3.3)
+      '@credo-ts/core': 0.5.18-alpha-20250926091534(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3)
       '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.20)
@@ -6471,7 +6471,7 @@ snapshots:
       - supports-color
       - web-streams-polyfill
 
-  '@credo-ts/core@0.5.18-alpha-20250903145047(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3)':
+  '@credo-ts/core@0.5.18-alpha-20250926091534(expo@54.0.10(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(react@19.1.1))(react-native@0.81.4(@babel/core@7.28.4)(react@19.1.1))(web-streams-polyfill@3.3.3)':
     dependencies:
       '@animo-id/mdoc': 0.2.38
       '@animo-id/pex': 4.1.1-alpha.0
@@ -9076,7 +9076,7 @@ snapshots:
 
   dotenv-expand@11.0.7:
     dependencies:
-      dotenv: 16.4.7
+      dotenv: 16.6.1
     optional: true
 
   dotenv@16.4.5: {}


### PR DESCRIPTION
Update VS Agent to 1.5.0-dev.3 to support SHA-512 verification. Needed for some European passports (see #92).