### PR TITLE
fix: use production CMD in Dockerfile to prevent EMFILE errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY tsconfig.json tsconfig.build.json nest-cli.json ./
 COPY ./src ./src
 
 RUN pnpm build
-CMD pnpm start
+CMD ["node", "dist/main"]


### PR DESCRIPTION
Change: CMD pnpm start → CMD ["node", "dist/main"], avoids nest start's chokidar file watching which causes EMFILE in containers.